### PR TITLE
[CLEANUP] Remove the TYPO3_PATH_ROOT settings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 env:
   global:
   - typo3DatabaseHost=localhost typo3DatabaseName=typo3 typo3DatabaseUsername=travis typo3DatabasePassword=''
-  - TYPO3_PATH_ROOT=$PWD/.Build/public
   matrix:
   - TYPO3_VERSION="^8.7" DEPENDENCIES=latest
   - TYPO3_VERSION="^8.7" DEPENDENCIES=oldest


### PR DESCRIPTION
This environment variable is not needed anymore.